### PR TITLE
Add Travis-CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: cpp
+compiler: gcc
+sudo: required
+install:
+  - sudo apt-get update
+  - sudo ./install-deps.sh
+  - if [ -x /usr/bin/python2 ]; then test -e /usr/bin/python && echo Done || sudo ln -sfn python2 /usr/bin/python; fi
+script: ./configure && make

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ TOUCH=touch
 
 INSTALL_DIRS:=
 INSTALL_DSTS:=
-CXX:=g++#./gstlfilt/gfilt
+CXX?=g++ #./gstlfilt/gfilt
 LXXFLAGS:=-Lobj/ $(patsubst %,-l%,$(LIBS))
 ifeq ($(OPT),)
 OPT := -O2
@@ -47,7 +47,7 @@ SYS_LIBS:=$(BOOST_SYSTEM) $(BOOST_THREAD) -lboost_signals -lpthread $(STATGRAB) 
 all:	$(DIR_DEPS) $(LIB_DEPS) $(BINS) tests ftests
 
 dpkg:
-	env DEB_BUILD_OPTIONS="nostrip" debuild -us -uc   
+	env DEB_BUILD_OPTIONS="nostrip" debuild -us -uc
 	@echo done
 
 build:	$(DIR_DEPS) $(BINS)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 istatd
 ======
 
+[![Build Status](https://travis-ci.org/ambakshi/istatd.svg?branch=master)](https://travis-ci.org/ambakshi/istatd)
+
 Check with jwatte@imvu.com for more information. Released under MIT 
 license. All rights reserved. Copyright 2011-2014 IMVU, Inc. Some
 contributions in the contrib subdirectory may be released under 

--- a/configure
+++ b/configure
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Simple configuration script for people who expect such a script to exist.
-# Please do not convert istatd to autotools. We will likely not accept such 
+# Please do not convert istatd to autotools. We will likely not accept such
 # a conversion. Thanks for your interest in istatd, and good luck!
 
 set -e
@@ -10,7 +10,7 @@ rm -f makevars.config
 rm -f config.h
 
 # Find Python version 2.
-# If this fails, you need to create appropriate aliases or symlinks for 
+# If this fails, you need to create appropriate aliases or symlinks for
 # testing to work!
 /usr/bin/env python -V
 /usr/bin/env python2 -V
@@ -18,6 +18,28 @@ rm -f config.h
 if curl --help >/dev/null 2>&1; then echo "Found curl in path."; else
     echo "You need to install the command-line tool 'curl'."
     exit 1
+fi
+
+if ! which jq >/dev/null 2>&1; then
+    case "`uname`" in
+        [Dd]arwin)
+            jqos=osx ;;
+        [Ll]inux)
+            jqos=linux ;;
+        *)
+            echo "You need to install the command-line tool 'jq'."
+            echo "Try http://stedolan.github.io/jq or your package manager."
+            exit 1 ;;
+    esac
+    if [ "`uname -m`" = "x86_64" ]; then
+        jqos="${jqos}64"
+    else
+        jqos="${jqos}32"
+    fi
+    mkdir -p bin
+    curl -sSL "http://stedolan.github.io/jq/download/${jqos}/jq" > jq.$$
+    mv jq.$$ jq
+    chmod +x jq
 fi
 
 if cat /dev/null | zlib-flate -compress; then echo "Found zlib-flate in path."; else

--- a/ftest/functions
+++ b/ftest/functions
@@ -14,7 +14,7 @@ export EXIT_HOOK=""
 
 # do a bit of a fail-safe to make sure we don't hang forever
 export ALARMPARENT=$$
-(sleep 30; echo "Test process timed out."; kill -9 $ALARMPARENT; [ -z "$DEBUG_ISTATD" ] && killall -q -9 istatd && killall -q -9 istatd_transplant; exit 1) &
+(sleep 30; echo "Test process timed out."; kill -9 $ALARMPARENT; [ -z "$DEBUG_ISTATD" ] && killall -q -9 istatd && killall -q -9 istatd_transplant; exit 1) </dev/null &
 ALARMCHILD=$!
 
 function failure {
@@ -132,7 +132,7 @@ function start_server {
     fi
     [ -f ftest/$CONFIG.cfg ] || failure "cannot find config file ftest/$CONFIG.cfg"
     if [ -z "$DEBUG_ISTATD" ]; then
-        bin/istatd --debug segv --config ftest/$CONFIG.cfg $maybe_store --settings $DBDIR/$CONFIG-settings --pid-file $DBDIR/$CONFIG-pid.pid --log-file $DBDIR/$CONFIG-log.log --daemonize $* > $DBDIR/$CONFIG-stdouterr 2>&1
+        bin/istatd --debug segv --config ftest/$CONFIG.cfg $maybe_store --settings $DBDIR/$CONFIG-settings --pid-file $DBDIR/$CONFIG-pid.pid --log-file $DBDIR/$CONFIG-log.log --daemonize $* > $DBDIR/$CONFIG-stdouterr 2>&1 </dev/null
         istatd_launch=$?
     else
         echo "========= start istatd with these arguments =========="
@@ -267,13 +267,13 @@ function test_counter {
     #flush_istatd $PROFILE
     VALUES=( `bin/istatd_filedump $FILENAME | tail -n +2 | sed -e 's/[^,]*,\\([^,]*\\),.*/\\1/'` )
     COUNT=${#VALUES[@]}
-    
+
     if [ $COUNT != $# ]; then
         bin/istatd_filedump $FILENAME
         failure "Wrong file length for $FILENAME - expected exactly $# bucket(s), but got $COUNT bucket(s) instead."
     else
         for (( i=1; i<=$COUNT; i++ )); do
-            value=${VALUES[$i - 1]} 
+            value=${VALUES[$i - 1]}
             if [ $value != ${!i} ]; then
                 bin/istatd_filedump $FILENAME
                 failure "Wrong sum in bucket $i of $FILENAME - expected ${!i}, but got $value instead."
@@ -528,6 +528,26 @@ function assert_files_equal {
     rm -f $TMPF
 }
 
+function assert_json_equal {
+    FILE1=$1
+    FILE2=$2
+    EXP="'$3|@csv'"
+    TMPF1=/var/tmp/assert_json_equal_$$-1.csv
+    TMPF2=/var/tmp/assert_json_equal_$$-2.csv
+    TMPF=/var/tmp/assert_json_equal_$$.txt
+    jq  -r $EXP $FILE1 | sort > $TMPF1
+    jq  -r $EXP $FILE2 | sort > $TMPF2
+    if ! diff $TMPF1 $TMPF2 > $TMPF 2>&1; then
+        echo "FAILURE: $TEST_NAME"
+        echo "test_output < $FILE1"
+        echo "test_expect > $FILE2"
+        cat $TMPF $TMPF1 $TMPF2
+        rm -f $TMPF $TMPF1 $TMPF2
+        exit 1
+    fi
+    rm -f $TMPF $TMPF1 $TMPF2
+}
+
 function assert_expected {
     RESULT_F=$1
     EXPECT_F=ftest/expected/$FTEST_NAME/$TEST_NAME
@@ -536,13 +556,21 @@ function assert_expected {
     assert_files_equal $RESULT_F $EXPECT_F
 }
 
+function assert_expected_json {
+    RESULT_F=$1
+    EXPECT_F=ftest/expected/$FTEST_NAME/$TEST_NAME
+    [ -d ftest/expected ] || failure "dir does not exist: ftest/expected"
+    [ -d ftest/expected/$FTEST_NAME ] || failure "dir does not exist: ftest/expected/$FTEST_NAME"
+    assert_json_equal $RESULT_F $EXPECT_F '.matching_names[]|[.name,.is_leaf,.type]'
+}
+
 TEST_NUM=0
 TEST_OUT=/var/tmp/test_out_$$
 EXPECT_OUT=/var/tmp/expect_out_$$
 TEST_NAME=""
 function test_name {
     TEST_NAME=$1
-    let TEST_NUM=$TEST_NUM+1    
+    let TEST_NUM=$TEST_NUM+1
     TEST_NUM_STR=`printf "%03d" $TEST_NUM`
     TEST_OUT=$DBDIR/test_${TEST_NUM_STR}
     EXPECT_OUT=$DBDIR/expect_${TEST_NUM_STR}

--- a/ftest/test_json_interface.sh
+++ b/ftest/test_json_interface.sh
@@ -124,7 +124,7 @@ start_server single --fake-time 2600
 
 test_name GET_counter_list_returns_counter_type
 curl -s "http://localhost:18011/?q=*" > $TEST_OUT
-assert_expected $TEST_OUT
+assert_expected_json $TEST_OUT
 
 
 cleanup_test

--- a/ftest/test_transplant.sh
+++ b/ftest/test_transplant.sh
@@ -79,7 +79,7 @@ function kill_transplant {
 echo "starting server"
 EXIT_HOOK="kill_transplant"
 echo "$TRANSPLANT" --listen 9156 --store "$MASTERDIR" --pidfile master-pid.pid --debug
-     "$TRANSPLANT" --listen 9156 --store "$MASTERDIR" --pidfile master-pid.pid --debug > "$DBDIR/master.log" 2>&1 &
+     "$TRANSPLANT" --listen 9156 --store "$MASTERDIR" --pidfile master-pid.pid --debug > "$DBDIR/master.log" 2>&1 </dev/null &
 MASTERPID="$!"
 
 wait_for_file "$MASTERDIR/master-pid.pid"

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+DEPS='qpdf curl ca-certificates build-essential make gcc g++ git python python-dev libboost-all-dev psmisc file autoconf autotools-dev automake jq'
+NPROC="$(grep processor /proc/cpuinfo 2>/dev/null | wc -l)"
+
+apt-get install -qq -y --no-install-recommends $DEPS
+
+if [ ! -d /tmp/libstatgrab ]; then
+    git clone --depth=1 -q https://github.com/imvu-open/libstatgrab /tmp/libstatgrab
+    cd /tmp/libstatgrab
+    ./configure --prefix=/usr
+    make -j${NPROC-1}
+    make install
+fi

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -18,4 +18,4 @@ mkdir -p /var/tmp/istatd-quickstart/store
 mkdir -p /var/tmp/istatd-quickstart/settings
 ln -sf `pwd`/files /var/tmp/istatd-quickstart/files
 echo "istatd starting up -- hit localhost:18011 in a browser to see it in action"
-bin/istatd --config quickstart.cfg --user `logname`
+bin/istatd --config quickstart.cfg --user ${LOGNAME:-`logname`}


### PR DESCRIPTION
Most of the changes were made to allow this code to be
built on travis-ci, a free continous integration service.
Notably, the code had to make sure to close stdin when
forking a process. In one of the tests comparing json
documents, the test was changed to use a sorted csv of
json properties. A direct comparison using just diff produces
wrong results, as json properties are unordered.
