### PR TITLE
Fix build on debian jessie

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,7 @@ $(foreach file,$(FILES_SRCS),$(eval $(call add_install,$(file),$(USR_PREFIX)/sha
 
 # add install must go before make directories
 $(foreach dir,$(INSTALL_DIRS),$(eval $(call mk_install_dir,$(patsubst %/,%,$(dir)))))
+$(foreach dir,$(INSTALL_DIRS),$(eval $(call mk_install_dir,$(dir))))
 $(call mk_install_dir,$(VAR_PREFIX)/db/istatd)
 
 install:	$(INSTALL_DIRS) $(INSTALL_DSTS)


### PR DESCRIPTION
I failed to follow through the logic of the makefile, or work out why this is different on debian jessie, but this ended up generating a dependency on the directory including a trailing slash, but the generated build rule to mkdir the directory is being generated with the trailing slash stripped on line 113.